### PR TITLE
#58 Update name space to preserve compatibility with php56

### DIFF
--- a/src/Task/DeployTasks.php
+++ b/src/Task/DeployTasks.php
@@ -4,7 +4,7 @@ namespace Droath\ProjectX\Task;
 
 use Droath\ProjectX\Project\NullProjectType;
 use Droath\ProjectX\ProjectX;
-use Droath\RoboGitHub\Task\loadTasks as githubTasks;
+use Droath\RoboGitHub\Task\loadTasks;
 use Robo\Contract\TaskInterface;
 use Robo\Contract\VerbosityThresholdInterface;
 use Robo\Task\Filesystem\loadTasks as filesystemTasks;
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Question\Question;
  */
 class DeployTasks extends TaskBase
 {
-    use githubTasks;
+    use loadTasks;
     use filesystemTasks;
 
     /**


### PR DESCRIPTION
I don't fully understand why name spacing this trait like this fixes this issue, but regardless this works for me using `php 5.6.32` as my cli version.

It's weird because you're doing the same thing with `filesystemTasks`