### PR TITLE
#72 deploy build with composer prefer dist

### DIFF
--- a/src/Project/PhpProjectType.php
+++ b/src/Project/PhpProjectType.php
@@ -289,12 +289,14 @@ abstract class PhpProjectType extends ProjectType
 
         $this->taskComposerUpdate()
             ->noDev()
+            ->preferDist()
             ->workingDir($build_root)
             ->option('lock')
             ->run();
 
         $this->taskComposerInstall()
             ->noDev()
+            ->preferDist()
             ->option('quiet')
             ->noInteraction()
             ->workingDir($build_root)


### PR DESCRIPTION
This will prevent adding `.git` directories when dist version is available, which would at lest cover github.com and drupal.org.